### PR TITLE
Fix rsr band calculation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/transformation/RSRTransformationHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/transformation/RSRTransformationHelper.kt
@@ -13,7 +13,7 @@ fun getRSRBand(rsrScore: Double?): RiskBand {
   if (rsrScore == null) throw IllegalArgumentException("RSR Score is null")
   return when {
     rsrScore >= 0.0 && rsrScore <= 3.0 -> RiskBand.LOW
-    rsrScore > 3.0 && rsrScore <= 6.8 -> RiskBand.MEDIUM
+    rsrScore > 3.0 && rsrScore < 6.9 -> RiskBand.MEDIUM
     rsrScore >= 6.9 -> RiskBand.HIGH
     else -> throw IllegalArgumentException("RSR Score out of supported range: $rsrScore")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/transformation/RSRTransformationHelperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/transformation/RSRTransformationHelperTest.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.arnsriskactuarialapi.service.transformation
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.RiskBand
+
+class RSRTransformationHelperTest {
+
+  @Test
+  fun `should return LOW for RSR score within 0 point 0 to 3 point 0`() {
+    assertEquals(RiskBand.LOW, getRSRBand(0.0))
+    assertEquals(RiskBand.LOW, getRSRBand(1.5))
+    assertEquals(RiskBand.LOW, getRSRBand(3.0))
+  }
+
+  @Test
+  fun `should return MEDIUM for RSR score within 3 point 0 to 6 point 8`() {
+    assertEquals(RiskBand.MEDIUM, getRSRBand(3.1))
+    assertEquals(RiskBand.MEDIUM, getRSRBand(5.5))
+    assertEquals(RiskBand.MEDIUM, getRSRBand(6.87))
+    assertEquals(RiskBand.MEDIUM, getRSRBand(6.81))
+    assertEquals(RiskBand.MEDIUM, getRSRBand(6.82))
+  }
+
+  @Test
+  fun `should return HIGH for RSR score 6 point 9 or above`() {
+    assertEquals(RiskBand.HIGH, getRSRBand(6.9))
+    assertEquals(RiskBand.HIGH, getRSRBand(10.0))
+  }
+
+  @Test
+  fun `should throw IllegalArgumentException for null RSR score`() {
+    val exception = assertThrows<IllegalArgumentException> {
+      getRSRBand(null)
+    }
+    assertEquals("RSR Score is null", exception.message)
+  }
+
+  @Test
+  fun `should throw IllegalArgumentException for negative RSR score`() {
+    val exception = assertThrows<IllegalArgumentException> {
+      getRSRBand(-1.0)
+    }
+    assertEquals("RSR Score out of supported range: -1.0", exception.message)
+  }
+}


### PR DESCRIPTION
java.lang.IllegalArgumentException: RSR Score out of supported range: 6.87
        at [uk.gov](http://uk.gov/).justice.digital.hmpps.arnsriskactuarialapi.service.transformation.RSRTransformationHelperKt.getRSRBand(RSRTransformationHelper.kt:18)
        
        Fix for exception on numbers between 6.8 and 6.9