### PR TITLE
Fix polynomial calculation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/transformation/SNSVTransformationHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/transformation/SNSVTransformationHelper.kt
@@ -4,7 +4,7 @@ import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.CustodyOrCommunity
 import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.Gender
 import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.PreviousConviction
 import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.ProblemLevel
-import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.utils.hornersMethod
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.utils.calculatePolynomial
 import java.time.LocalDate
 import java.time.Period
 import java.time.temporal.ChronoUnit
@@ -66,10 +66,10 @@ class SNSVTransformationHelper {
       .let { x ->
         when (gender) {
           Gender.MALE -> (if (isSNSVDynamic) DYNAMIC_AGE_MALE_COEFFS else STATIC_AGE_MALE_COEFFS).let {
-            x * hornersMethod(it, x)
+            x * calculatePolynomial(it, x)
           }
           Gender.FEMALE -> (if (isSNSVDynamic) DYNAMIC_AGE_FEMALE_COEFFS else STATIC_AGE_FEMALE_COEFFS).let {
-            x * hornersMethod(it, x) - 16.6927292697847
+            x * calculatePolynomial(it, x) - 16.6927292697847
           }
         }
       }
@@ -109,7 +109,7 @@ class SNSVTransformationHelper {
       }
       val monthsSinceLastSanction = ChronoUnit.MONTHS.between(assessmentDate, dateAtStartOfFollowup).toInt()
       val coeffs = if (isSNSVDynamic) DYNAMIC_MONTHS_SINCE_LAST_SANCTION_WEIGHTS else STATIC_MONTHS_SINCE_LAST_SANCTION_WEIGHTS
-      return monthsSinceLastSanction * hornersMethod(coeffs, monthsSinceLastSanction.toDouble())
+      return monthsSinceLastSanction * calculatePolynomial(coeffs, monthsSinceLastSanction.toDouble())
     }
 
     fun getThreePlusSanctionsWeight(gender: Gender, totalNumberOfSanctionsForAllOffences: Int, ageAtFirstSanction: Int, dateOfBirth: LocalDate, dateOfCurrentConviction: LocalDate, isSNSVDynamic: Boolean): Double {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/utils/NumbersUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/utils/NumbersUtils.kt
@@ -4,6 +4,7 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import kotlin.collections.fold
 import kotlin.math.exp
+import kotlin.math.pow
 
 fun Double.asDoublePercentage(): Double = BigDecimal(this).multiply(BigDecimal.valueOf(100)).setScale(2, RoundingMode.HALF_UP).toDouble()
 fun Double.roundToNDecimals(n: Int): Double = BigDecimal(this).setScale(n, RoundingMode.HALF_UP).toDouble()
@@ -22,4 +23,4 @@ fun Int.sanitisePercentage(): Int = when {
 
 fun Double.sigmoid(): Double = exp(this).let { it / (1 + it) }
 
-fun hornersMethod(coeffs: DoubleArray, x: Double): Double = (coeffs.size - 1 downTo 0).fold(0.0) { sum, i -> sum * x + coeffs[i] }
+fun calculatePolynomial(coeffs: DoubleArray, x: Double): Double = (0..<coeffs.size).fold(0.0) { sum, i -> sum + coeffs[i] * x.pow(i) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/utils/NumbersUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/utils/NumbersUtilsTest.kt
@@ -78,14 +78,14 @@ class NumbersUtilsTest {
   }
 
   @Test
-  fun `horner's method calculations`() {
-    assertEquals(7.0, hornersMethod(cubic, 2.0), 0.00001)
-    assertEquals(PI - 1, hornersMethod(linear, PI), 0.00001)
-    assertEquals(21.0, hornersMethod(quadratic, 4.0), 0.00001)
+  fun `polynomial calculations`() {
+    assertEquals(7.0, calculatePolynomial(cubic, 2.0), 0.00001)
+    assertEquals(PI - 1, calculatePolynomial(linear, PI), 0.00001)
+    assertEquals(21.0, calculatePolynomial(quadratic, 4.0), 0.00001)
     // should be true for any x
     val x = PI
-    val productOfPolynomials = { x: Double -> hornersMethod(linear, x) * hornersMethod(quadratic, x) }
-    val cubicPolynomial = { x: Double -> hornersMethod(cubic, x) }
+    val productOfPolynomials = { x: Double -> calculatePolynomial(linear, x) * calculatePolynomial(quadratic, x) }
+    val cubicPolynomial = { x: Double -> calculatePolynomial(cubic, x) }
     assertEquals(productOfPolynomials(x), cubicPolynomial(x), 0.00001)
   }
 }


### PR DESCRIPTION
Turns out that for low degree polynomials the kotlin math pow function is more efficient than horner's method. Basically, this is because the kotlin "pow" function (in particular the one in _kotlin.math.pow_) is implemented within the platform. i.e. is a native implementation.