### PR TITLE
ACT-120: Consolidate fields error responses NULL vs Empty

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/dto/ValidationErrorResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/dto/ValidationErrorResponse.kt
@@ -3,5 +3,5 @@ package uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto
 data class ValidationErrorResponse(
   val type: ValidationErrorType,
   val message: String,
-  val fields: List<String>?,
+  val fields: List<String>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/OGPRiskProducerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/OGPRiskProducerService.kt
@@ -128,7 +128,7 @@ class OGPRiskProducerService : RiskScoreProducer {
           ValidationErrorResponse(
             type = ValidationErrorType.UNEXPECTED_VALUE,
             message = "Error: ${it.message}",
-            fields = null,
+            fields = emptyList(),
           ),
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/OGRS3RiskProducerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/OGRS3RiskProducerService.kt
@@ -105,7 +105,7 @@ class OGRS3RiskProducerService : RiskScoreProducer {
         ValidationErrorResponse(
           type = ValidationErrorType.NO_MATCHING_INPUT,
           message = "Error: ${it.message}",
-          fields = null,
+          fields = emptyList(),
         ),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/OSPDCRiskProducerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/OSPDCRiskProducerService.kt
@@ -98,7 +98,7 @@ class OSPDCRiskProducerService : RiskScoreProducer {
               ValidationErrorResponse(
                 type = ValidationErrorType.NOT_APPLICABLE,
                 message = "OSP/DC band not applicable, 64 point score value: 0",
-                fields = null,
+                fields = emptyList(),
               ),
             ),
           )
@@ -118,7 +118,7 @@ class OSPDCRiskProducerService : RiskScoreProducer {
         ValidationErrorResponse(
           type = ValidationErrorType.UNEXPECTED_VALUE,
           message = "Error: ${it.message}",
-          fields = null,
+          fields = emptyList(),
         ),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/RSRRiskProducerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/RSRRiskProducerService.kt
@@ -58,7 +58,7 @@ class RSRRiskProducerService : RiskScoreProducer {
         ValidationErrorResponse(
           type = ValidationErrorType.UNEXPECTED_VALUE,
           message = "Error: ${e.message}",
-          fields = null,
+          fields = emptyList(),
         ),
       )
       return context.apply {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/SNSVRiskProducerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/SNSVRiskProducerService.kt
@@ -89,7 +89,7 @@ class SNSVRiskProducerService : RiskScoreProducer {
         ValidationErrorResponse(
           type = ValidationErrorType.UNEXPECTED_VALUE,
           message = "Error: ${it.message}",
-          fields = null,
+          fields = emptyList(),
         ),
       ),
     )

--- a/src/test/resources/responses/ogrs3-expected-3.json
+++ b/src/test/resources/responses/ogrs3-expected-3.json
@@ -6,7 +6,7 @@
     "validationError" : [ {
       "type" : "NO_MATCHING_INPUT",
       "message" : "Error: Conviction date cannot be before date of birth.",
-      "fields" : null
+      "fields" : []
     } ]
   }
 }

--- a/src/test/resources/responses/snsv-expected-dynamic-2.json
+++ b/src/test/resources/responses/snsv-expected-dynamic-2.json
@@ -6,7 +6,7 @@
       {
         "type": "UNEXPECTED_VALUE",
         "message": "Error: Age at assessment date cannot be less than 10",
-        "fields": null
+        "fields": []
       }
     ]
   }


### PR DESCRIPTION
Besides inconsistent error messages we should also fix the 

`val fields: List<String>?,`

making it not nullable because we have inconsistent error fields list being either null or empty lists. 
Always returning a value is more consistent for our end users not forcing them to check for nulls.