### PR TITLE
ACT-140: Fix SNSV scoreType mismatching

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/dto/snsv/SNSVDynamicRequestValidated.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/dto/snsv/SNSVDynamicRequestValidated.kt
@@ -19,7 +19,7 @@ data class SNSVDynamicRequestValidated(
   val totalNumberOfViolentSanctions: Int,
   val didOffenceInvolveCarryingOrUsingWeapon: Boolean,
   val suitabilityOfAccommodation: ProblemLevel,
-  val isUnemployed: Boolean,
+  val isUnemployed: Boolean?,
   val currentRelationshipWithPartner: ProblemLevel,
   val currentAlcoholUseProblems: ProblemLevel,
   val excessiveAlcoholUse: ProblemLevel,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/SNSVRiskProducerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/SNSVRiskProducerService.kt
@@ -41,7 +41,6 @@ class SNSVRiskProducerService : RiskScoreProducer {
     val SNSV_DYNAMIC_ADDITIONAL_REQUIRED_PROPERTIES = listOf(
       RiskScoreRequest::didOffenceInvolveCarryingOrUsingWeapon,
       RiskScoreRequest::suitabilityOfAccommodation,
-      RiskScoreRequest::isUnemployed,
       RiskScoreRequest::currentRelationshipWithPartner,
       RiskScoreRequest::currentAlcoholUseProblems,
       RiskScoreRequest::excessiveAlcoholUse,
@@ -114,7 +113,7 @@ class SNSVRiskProducerService : RiskScoreProducer {
     this.totalNumberOfViolentSanctions!!.toInt(),
     this.didOffenceInvolveCarryingOrUsingWeapon!!,
     this.suitabilityOfAccommodation!!,
-    this.isUnemployed!!,
+    this.isUnemployed,
     this.currentRelationshipWithPartner!!,
     this.currentAlcoholUseProblems!!,
     this.excessiveAlcoholUse!!,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/transformation/SNSVTransformationHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/transformation/SNSVTransformationHelper.kt
@@ -163,7 +163,7 @@ class SNSVTransformationHelper {
 
     fun suitabilityOfAccommodationWeight(suitabilityOfAccommodation: ProblemLevel): Double = 0.0619710049121293 * suitabilityOfAccommodation.score
 
-    fun isUnemployedWeight(isUnemployed: Boolean): Double = if (isUnemployed) 0.0389109699626767 * 2 else 0.0
+    fun isUnemployedWeight(isUnemployed: Boolean?): Double = if (isUnemployed == true) 0.0389109699626767 * 2 else 0.0
 
     fun currentRelationshipWithPartnerWeight(currentRelationshipWithPartner: ProblemLevel): Double = when (currentRelationshipWithPartner) {
       ProblemLevel.NO_PROBLEMS -> 0.0


### PR DESCRIPTION
Fixes when scoreType  should be DYNAMIC but we returned as STATIC instead.

by running some data analysis I found 11852 out of 49366 currently mismatch on the score type (24%) this fix reduce it to 0 (specifically for this issue not all other issues)

Because OASys isUnemployed (4.2) is either "YES" / "NO" / "NA" / null