### PR TITLE
ACT-98: Fix OSPIIC bands

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/dto/ospiic/OSPIICHierarchyBand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/dto/ospiic/OSPIICHierarchyBand.kt
@@ -12,9 +12,9 @@ enum class OSPIICHierarchyBand(
   val band: RiskBand,
   val isMatchFor: (OSPIICInputValidated) -> Boolean,
 ) {
-  TwoOrMoreIIOCSanctions(0.10310, RiskBand.VERY_HIGH, twoOrMoreIIOCSanctions),
-  OneIIOCSanction(0.03328, RiskBand.HIGH, oneIIOCSanction),
-  TwoOrMoreContactChildSexualSanctions(0.00926, RiskBand.MEDIUM, twoOrMoreContactChildSexualSanctions),
+  TwoOrMoreIIOCSanctions(0.10310, RiskBand.HIGH, twoOrMoreIIOCSanctions),
+  OneIIOCSanction(0.03328, RiskBand.MEDIUM, oneIIOCSanction),
+  TwoOrMoreContactChildSexualSanctions(0.00926, RiskBand.LOW, twoOrMoreContactChildSexualSanctions),
   OneContactChildSexualSanctions(0.00634, RiskBand.LOW, oneContactChildSexualSanctions),
   NoSexualOffenceSanctions(0.00062, RiskBand.LOW, noSexualOffenceSanctions),
   AllOthers(0.00281, RiskBand.LOW, { _ -> true }),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/OSPIICRiskProducerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/OSPIICRiskProducerServiceTest.kt
@@ -31,7 +31,7 @@ class OSPIICRiskProducerServiceTest {
     )
     val result = service.getRiskScore(request, context)
     val output = result.OSPIIC
-    assertEquals(RiskBand.VERY_HIGH, output!!.band)
+    assertEquals(RiskBand.HIGH, output!!.band)
     assertEquals(0.1031, output.score!!, 0.00001)
     assertEquals(emptyList<ValidationErrorResponse>(), output.validationError)
   }


### PR DESCRIPTION
Before Fix
Completed. 47097 files processed. Mismatches found: 4932

With Fix applied
Completed. 47097 files processed. Mismatches found: 3992

