### PR TITLE
Fix missing sexual motivation question validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/transformation/RSRTransformationHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/transformation/RSRTransformationHelper.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.arnsriskactuarialapi.service.transformation
 
 import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.RiskBand
 
-fun getRSRBand(rsrScore: Double?): RiskBand {
-  if (rsrScore == null) throw IllegalArgumentException("RSR Score is null")
+fun getRSRBand(rsrScore: Double?): RiskBand? {
+  if (rsrScore == null) return null
   return when {
     rsrScore >= 0.0 && rsrScore <= 3.0 -> RiskBand.LOW
     rsrScore > 3.0 && rsrScore < 6.9 -> RiskBand.MEDIUM

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/validation/OSPDCValidationHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/validation/OSPDCValidationHelper.kt
@@ -1,9 +1,24 @@
 package uk.gov.justice.digital.hmpps.arnsriskactuarialapi.service.validation
 
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.Gender
 import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.RiskScoreRequest
 import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.ValidationErrorResponse
 
-fun ospdcInitialValidation(request: RiskScoreRequest): List<ValidationErrorResponse> = ospdcValidationMissingFields(request)
+fun ospdcInitialValidation(request: RiskScoreRequest): List<ValidationErrorResponse> = ospdcValidationMissingFields(request) + ospdcValidateSexualMotivationFields(request)
+
+internal fun ospdcValidateSexualMotivationFields(
+  request: RiskScoreRequest,
+): List<ValidationErrorResponse> {
+  val missingFields = arrayListOf<String>()
+  if (request.gender == Gender.MALE &&
+    request.hasEverCommittedSexualOffence == true &&
+    request.isCurrentOffenceSexuallyMotivated == null
+  ) {
+    missingFields.addIfNull(request, RiskScoreRequest::isCurrentOffenceSexuallyMotivated)
+  }
+
+  return addMissingFields(missingFields, emptyList())
+}
 
 internal fun ospdcValidationMissingFields(
   request: RiskScoreRequest,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/TestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/TestData.kt
@@ -285,6 +285,7 @@ fun validOSPDCRiskScoreRequest() = RiskScoreRequest(
   dateAtStartOfFollowup = LocalDate.of(2025, 1, 1),
   dateOfMostRecentSexualOffence = LocalDate.of(2000, 1, 1),
   totalNumberOfSanctionsForAllOffences = 4 as Integer,
+  isCurrentOffenceSexuallyMotivated = false,
 )
 
 fun validSNSVStaticRiskScoreRequest() = RiskScoreRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/RSRRiskProducerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/RSRRiskProducerServiceTest.kt
@@ -1,0 +1,104 @@
+package uk.gov.justice.digital.hmpps.arnsriskactuarialapi.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertNull
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.RiskBand
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.RiskScoreRequest
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.ValidationErrorResponse
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.ValidationErrorType
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.osp.OSPDCObject
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.ospiic.OSPIICObject
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.snsv.SNSVObject
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.snsv.ScoreType
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.emptyContext
+
+class RSRRiskProducerServiceTest {
+
+  private val service = RSRRiskProducerService()
+
+  @Test
+  fun `should calculate RSR score when no validation errors`() {
+    val context = emptyContext().copy(
+      OSPDC = OSPDCObject(ospdcScore = 0.0512312312, ospdcBand = RiskBand.LOW, validationError = emptyList()),
+      OSPIIC = OSPIICObject(score = 0.0212312312, band = RiskBand.MEDIUM, validationError = emptyList()),
+      SNSV = SNSVObject(snsvScore = 0.0312312312, scoreType = ScoreType.DYNAMIC, validationError = emptyList()),
+    )
+
+    val result = service.getRiskScore(RiskScoreRequest(), context)
+
+    val rsr = result.RSR!!
+    assertEquals(RiskBand.LOW, rsr.ospdcBand)
+    assertEquals(5.12, rsr.ospdcScore)
+    assertEquals(RiskBand.MEDIUM, rsr.ospiicBand)
+    assertEquals(2.12, rsr.ospiicScore)
+    assertEquals(10.36, rsr.rsrScore)
+    assertNotNull(rsr.rsrBand)
+    assertEquals(ScoreType.DYNAMIC, rsr.scoreType)
+    assertTrue(rsr.validationError?.isEmpty() == true)
+  }
+
+  @Test
+  fun `should return null RSR and null scoreType when blocking errors exist `() {
+    val errors = listOf(
+      ValidationErrorResponse(
+        type = ValidationErrorType.MISSING_INPUT,
+        message = "ERR",
+        fields = listOf(RiskScoreRequest::isCurrentOffenceSexuallyMotivated.name),
+      ),
+    )
+    val context = emptyContext().copy(
+      OSPDC = OSPDCObject(ospdcScore = 0.02378462734, ospdcBand = RiskBand.LOW, validationError = errors),
+    )
+
+    val result = service.getRiskScore(RiskScoreRequest(), context)
+
+    val rsr = result.RSR!!
+    assertNull(rsr.rsrScore)
+    assertNull(rsr.rsrBand)
+    assertNull(rsr.scoreType)
+    assertEquals(errors, rsr.validationError)
+  }
+
+  @Test
+  fun `should handle null OSPDC and OSPIIC inputs gracefully`() {
+    val context = emptyContext()
+
+    val result = service.getRiskScore(RiskScoreRequest(), context)
+
+    val rsr = result.RSR!!
+    assertEquals(0.0, rsr.ospdcScore)
+    assertEquals(RiskBand.NOT_APPLICABLE, rsr.ospdcBand)
+    assertEquals(0.0, rsr.ospiicScore)
+    assertEquals(RiskBand.NOT_APPLICABLE, rsr.ospiicBand)
+    assertEquals(0.0, rsr.rsrScore)
+    assertNotNull(rsr.rsrBand)
+    assertNull(rsr.scoreType)
+    assertTrue(rsr.validationError?.isEmpty() == true)
+  }
+
+  @Test
+  fun `hasBlockingErrors should detect errors that block RSR score`() {
+    val service = RSRRiskProducerService()
+
+    val blockingError = listOf(
+      ValidationErrorResponse(
+        type = ValidationErrorType.MISSING_INPUT,
+        message = "ERR",
+        fields = listOf(RiskScoreRequest::isCurrentOffenceSexuallyMotivated.name),
+      ),
+    )
+    val nonBlockingError = listOf(
+      ValidationErrorResponse(
+        type = ValidationErrorType.MISSING_INPUT,
+        message = "ERR",
+        fields = listOf(RiskScoreRequest::hasEverCommittedSexualOffence.name),
+      ),
+    )
+    assertTrue(service.hasBlockingErrors(blockingError))
+    assertFalse(service.hasBlockingErrors(nonBlockingError))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/transformation/RSRTransformationHelperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/transformation/RSRTransformationHelperTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.RiskBand
+import kotlin.test.assertNull
 
 class RSRTransformationHelperTest {
 
@@ -26,15 +27,11 @@ class RSRTransformationHelperTest {
   @Test
   fun `should return HIGH for RSR score 6 point 9 or above`() {
     assertEquals(RiskBand.HIGH, getRSRBand(6.9))
-    assertEquals(RiskBand.HIGH, getRSRBand(10.0))
   }
 
   @Test
-  fun `should throw IllegalArgumentException for null RSR score`() {
-    val exception = assertThrows<IllegalArgumentException> {
-      getRSRBand(null)
-    }
-    assertEquals("RSR Score is null", exception.message)
+  fun `should get null band for null RSR score`() {
+    assertNull(getRSRBand(null))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/validation/OSPDCValidationHelperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/service/validation/OSPDCValidationHelperTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.arnsriskactuarialapi.service.validation
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.Gender
 import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.ValidationErrorType
 import uk.gov.justice.digital.hmpps.arnsriskactuarialapi.validOSPDCRiskScoreRequest
 import kotlin.collections.listOf
@@ -43,6 +44,26 @@ class OSPDCValidationHelperTest {
       "totalIndecentImageSanctions",
       "dateAtStartOfFollowup",
       "totalNumberOfSanctionsForAllOffences",
+    )
+
+    val error = result.first()
+    assertEquals(ValidationErrorType.MISSING_INPUT, error.type)
+    assertEquals("ERR5 - Field is Null", error.message)
+    assertEquals(expectedFields, error.fields)
+  }
+
+  @Test
+  fun `oospdcInitialValidation missing sexual motivation question`() {
+    val request = validOSPDCRiskScoreRequest().copy(
+      gender = Gender.MALE,
+      hasEverCommittedSexualOffence = true,
+      isCurrentOffenceSexuallyMotivated = null,
+    )
+
+    val result = ospdcInitialValidation(request)
+
+    val expectedFields = listOf(
+      "isCurrentOffenceSexuallyMotivated",
     )
 
     val error = result.first()


### PR DESCRIPTION
- Applies the OSPCDC validation error "missing sexual motivation question" which also blocks RSR but should not prevent OSPIIC score to output

RSR test mismatches from 1001 to 952