### PR TITLE
ACT-160: Apply stricter validation for unknown fields in RiskScoreRequest

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/config/JacksonConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/config/JacksonConfig.kt
@@ -23,6 +23,7 @@ class JacksonConfig {
       .postConfigurer { mapper: ObjectMapper ->
         mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, false)
         mapper.configure(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS, true)
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
         mapper.configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true)
 
         listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/integration/controller/RiskScoreControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsriskactuarialapi/integration/controller/RiskScoreControllerTest.kt
@@ -189,4 +189,25 @@ class RiskScoreControllerTest : IntegrationTestBase() {
       .expectBody()
       .jsonPath("$.message").isEqualTo(expectedError)
   }
+
+  @Test
+  fun `postRiskScores returns 400 if unknown field is passed`() {
+    val expectedError =
+      "JSON parse error: Unrecognized field \"IdoNotExists\" (class uk.gov.justice.digital.hmpps.arnsriskactuarialapi.dto.RiskScoreRequest), not marked as ignorable"
+    webTestClient.post()
+      .uri("/risk-scores/v1")
+      .headers(setAuthorisation(roles = listOf("ARNS_RISK_ACTUARIAL")))
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(
+        """
+        {
+          "IdoNotExists": "1234"
+        }
+        """.trimIndent(),
+      )
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody()
+      .jsonPath("$.message").isEqualTo(expectedError)
+  }
 }

--- a/src/test/resources/requests/opd-input-2-female-valid.json
+++ b/src/test/resources/requests/opd-input-2-female-valid.json
@@ -26,7 +26,7 @@
   "overRelianceOnOthersForFinancialSupport": "SIGNIFICANT_PROBLEMS",
   "manipulativeOrPredatoryBehaviour": "SIGNIFICANT_PROBLEMS",
   "isEvidenceOfChildhoodBehaviouralProblems": false,
-  "historyOfPsychiatricTreatment": true,
+  "hasHistoryOfPsychiatricTreatment": true,
   "hasBeenOnMedicationForMentalHealthProblems": true,
   "hasEverBeenInSpecialHospitalOrRegionalSecureUnit": false,
   "hasSelfHarmOrAttemptedSuicide": false,


### PR DESCRIPTION
It returns 400 on requests that hold fields not existing on RiskScoreRequest, 
it actually highlighted some previous field renaming got lost in the process.